### PR TITLE
Fix for Issue #2 and Reworked travis.yml for easier maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+cache: pip
 
 env:
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ python:
     - "3.6"
     - "nightly"
 
+script:
+  coverage run runtests.py
+
+
 install:
   - travis_retry pip install $DJANGO
   - travis_retry pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 language: python
-python: 2.7
 sudo: false
 
 env:
-    - TOX_ENV=py27-django18
-    - TOX_ENV=py27-django19
-    - TOX_ENV=py27-django10
-    - TOX_ENV=py33-django18
-    - TOX_ENV=py34-django18
-    - TOX_ENV=py34-django19
-    - TOX_ENV=py34-django10
+  - DJANGO='https://github.com/django/django/archive/master.tar.gz'
+  - DJANGO='django>=1.10.0,<1.11.0'
+  - DJANGO='django>=1.9.0,<1.10.0'
+  - DJANGO='django>=1.8.0,<1.9.0'
+
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "nightly"
 
 install:
-  - pip install tox
-
-script:
-  - tox -e $TOX_ENV
+  - travis_retry pip install $DJANGO
+  - travis_retry pip install coveralls
+  - travis_retry pip install -r requirements.txt
+  
+after_success:
+    - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ python:
 install:
   - travis_retry pip install $DJANGO
   - travis_retry pip install coveralls
-  - travis_retry pip install -r requirements.txt
+  - travis_retry pip install -r test_requirements.txt
   
 after_success:
     - coveralls

--- a/quantityfield/widgets.py
+++ b/quantityfield/widgets.py
@@ -23,12 +23,12 @@ class QuantityWidget(MultiWidget):
 				)
 
 		super(QuantityWidget, self).__init__(widgets, attrs)
-        
-    def decompress(self, value):
-        non_decimal = re.compile(r'[^\d.]+')
-        if value:
-            number_value = non_decimal.sub('', str(value))
-            return [number_value, self.base_units]
+
+        def decompress(self, value):
+		non_decimal = re.compile(r'[^\d.]+')
+                if value:
+			number_value = non_decimal.sub('', str(value))
+			return [number_value, self.base_units]
 		return [None, self.base_units]
 
 

--- a/quantityfield/widgets.py
+++ b/quantityfield/widgets.py
@@ -1,4 +1,4 @@
-
+import re
 
 from django.forms.widgets import MultiWidget, Select, NumberInput
 
@@ -23,10 +23,12 @@ class QuantityWidget(MultiWidget):
 				)
 
 		super(QuantityWidget, self).__init__(widgets, attrs)
-
-	def decompress(self, value):
-		if value:
-			return [value, self.base_units]
+        
+    def decompress(self, value):
+        non_decimal = re.compile(r'[^\d.]+')
+        if value:
+            number_value = non_decimal.sub('', str(value))
+            return [number_value, self.base_units]
 		return [None, self.base_units]
 
 

--- a/quantityfield/widgets.py
+++ b/quantityfield/widgets.py
@@ -7,29 +7,26 @@ from . import ureg
 
 class QuantityWidget(MultiWidget):
 
-	def get_choices(self, allowed_types=None):
-		allowed_types = allowed_types or dir(ureg)			
-		return [(x, x) for x in allowed_types]
+    def get_choices(self, allowed_types=None):
+        allowed_types = allowed_types or dir(ureg)
+        return [(x, x) for x in allowed_types]
+        
+    def __init__(self, attrs=None, base_units=None, allowed_types=None):
+        choices = self.get_choices(allowed_types)
+        self.base_units = base_units
+        attrs = attrs or {}
+        attrs.setdefault('step', 'any')
 
-	def __init__(self, attrs=None, base_units=None, allowed_types=None):
-		choices = self.get_choices(allowed_types)
-		self.base_units = base_units
-		attrs = attrs or {}
-		attrs.setdefault('step', 'any')
+        widgets = (
+                    NumberInput(attrs=attrs),
+                    Select(attrs=attrs, choices=choices)
+                )
 
-		widgets = (
-					NumberInput(attrs=attrs),
-					Select(attrs=attrs, choices=choices)
-				)
-
-		super(QuantityWidget, self).__init__(widgets, attrs)
+        super(QuantityWidget, self).__init__(widgets, attrs)
 
         def decompress(self, value):
-		non_decimal = re.compile(r'[^\d.]+')
-                if value:
-			number_value = non_decimal.sub('', str(value))
-			return [number_value, self.base_units]
-		return [None, self.base_units]
-
-
-
+            non_decimal = re.compile(r'[^\d.]+')
+            if value:
+                number_value = non_decimal.sub('', str(value))
+                return [number_value, self.base_units]
+            return [None, self.base_units]


### PR DESCRIPTION
The widget decompress method needed to coerce the value for the number input. While I was there, I changed to spaces. Hope that's not a problem.

Also, I switched up the .travis.yml file. This will be easier for you to maintain as new versions of Django or Python get added, as this config automatically does all the combinations for every listed version of Python and Django. 

Additionally, coverage is now configured to run.